### PR TITLE
rollme fixes

### DIFF
--- a/.helm-shared/Chart.yaml
+++ b/.helm-shared/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 
 dependencies:
   - name: ioc-instance
-    version: 4.2.2
+    version: 4.3.0+b1
     repository: "oci://ghcr.io/epics-containers"

--- a/.helm-shared/Chart.yaml
+++ b/.helm-shared/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 
 dependencies:
   - name: ioc-instance
-    version: 4.3.0+b1
+    version: 4.3.0+b4
     repository: "oci://ghcr.io/epics-containers"

--- a/.helm-shared/Chart.yaml
+++ b/.helm-shared/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 
 dependencies:
   - name: ioc-instance
-    version: 4.3.0+b4
+    version: 4.3.0+b5
     repository: "oci://ghcr.io/epics-containers"

--- a/.helm-shared/Chart.yaml
+++ b/.helm-shared/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 
 dependencies:
   - name: ioc-instance
-    version: 4.3.0+b5
+    version: 4.3.0+b6
     repository: "oci://ghcr.io/epics-containers"

--- a/.helm-shared/Chart.yaml
+++ b/.helm-shared/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 
 dependencies:
   - name: ioc-instance
-    version: 4.3.0+b6
+    version: 4.3.0+b7
     repository: "oci://ghcr.io/epics-containers"

--- a/.helm-shared/Chart.yaml
+++ b/.helm-shared/Chart.yaml
@@ -7,5 +7,5 @@ type: application
 
 dependencies:
   - name: ioc-instance
-    version: 4.3.0+b7
+    version: 4.3.0+b8
     repository: "oci://ghcr.io/epics-containers"


### PR DESCRIPTION
switch rollme to use a commit hash instead of a random value

- use .Values.commitHash if it is set (argoCD will pass this down as $ARGOCD_APP_REVISION_SHORT)
- or continue to use a random value if commitHash is not set